### PR TITLE
Prevent namespace from getting into path when creating a onedrive item

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -87,6 +87,11 @@ class OneDriveItem():
             path = None
             oid = "root"
 
+        if path and ":" in path:
+            new_path = path.split(":")[1]
+            log.debug("Passed path containing namespace: %s, using path %s instead", path, new_path)
+            path = new_path
+
         self.__oid = oid
         self.__path = path
         self.__pid = pid


### PR DESCRIPTION
Having the namespace in the path of the onedrive item causes onedrive to complain the expression is not valid when getting the item using the direct sdk. It maybe makes sense to strip off the namespace in the initializer, or perhaps only when getting the api_path, allowing the other methods to have the path with the namespace. 