### PR TITLE
add timeout to direct api, in case sleep/wake causes https to hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint: requirements
 
 test: requirements
 	. env/$(ENVBIN)/activate && flit install
-	. env/$(ENVBIN)/activate && pytest -v --cov=. --cov-report=xml --durations=1 -n=4 --provider=onedrive,testodbiz tests
+	. env/$(ENVBIN)/activate && pytest -v --cov=. --cov-report=xml --durations=1 -n=2 --provider=onedrive,testodbiz tests
 
 format:
 	autopep8 --in-place -r -j 8 cloudsync/

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -690,7 +690,8 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                 name = urllib.parse.quote(base)
                 api_path += "/children('" + name + "')/content"
                 try:
-                    r = self._direct_api("put", api_path, data=file_like, headers={'content-type': 'text/plain'})  # default timeout ok, size == 0 from "if" condition
+                    headers = {'content-type': 'text/plain'}
+                    r = self._direct_api("put", api_path, data=file_like, headers=headers)  # default timeout ok, size == 0 from "if" condition
                 except CloudTemporaryError:
                     info = self.info_path(path)
                     # onedrive can fail with ConnectionResetByPeer, but still secretly succeed... just without returning info

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -720,7 +720,8 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                 clen = len(data)             # fragment content size
                 cbto = cbfrom + clen - 1     # inclusive content byte range
                 cbrange = "bytes %s-%s/%s" % (cbfrom, cbto, size)
-                r = self._direct_api("put", url=upload_url, data=data, headers={"Content-Length": clen, "Content-Range": cbrange}, timeout=7200)
+                headers = {"Content-Length": clen, "Content-Range": cbrange}
+                r = self._direct_api("put", url=upload_url, data=data, headers=headers)
                 data = file_like.read(self.upload_block_size)
                 cbfrom = cbto + 1
             return r
@@ -731,7 +732,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
     def download(self, oid, file_like):
         with self._api() as client:
             info = self._get_item(client, oid=oid)
-            r = self._direct_api("get", info.api_path + "/content", stream=True, timeout=7200)
+            r = self._direct_api("get", info.api_path + "/content", stream=True)
             for chunk in r.iter_content(chunk_size=4096):
                 file_like.write(chunk)
                 file_like.flush()

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -226,7 +226,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             return client.base_url.rstrip("/") + "/" + api_path
 
     # names of args are compat with requests module
-    def _direct_api(self, action, path=None, *, url=None, stream=None, data=None, headers=None, json=None, raw_response=False):  # pylint: disable=redefined-outer-name
+    def _direct_api(self, action, path=None, *, url=None, stream=None, data=None, headers=None, json=None, raw_response=False, timeout=600):  # pylint: disable=redefined-outer-name
         assert path or url
 
         if not url:
@@ -249,7 +249,9 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                 stream=stream,
                 headers=head,
                 json=json,
-                data=data)
+                data=data,
+                timeout=timeout
+            )
 
         if raw_response:
             return req

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -690,7 +690,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                 name = urllib.parse.quote(base)
                 api_path += "/children('" + name + "')/content"
                 try:
-                    r = self._direct_api("put", api_path, data=file_like, headers={'content-type': 'text/plain'})
+                    r = self._direct_api("put", api_path, data=file_like, headers={'content-type': 'text/plain'})  # default timeout ok, size == 0 from "if" condition
                 except CloudTemporaryError:
                     info = self.info_path(path)
                     # onedrive can fail with ConnectionResetByPeer, but still secretly succeed... just without returning info
@@ -719,7 +719,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                 clen = len(data)             # fragment content size
                 cbto = cbfrom + clen - 1     # inclusive content byte range
                 cbrange = "bytes %s-%s/%s" % (cbfrom, cbto, size)
-                r = self._direct_api("put", url=upload_url, data=data, headers={"Content-Length": clen, "Content-Range": cbrange})
+                r = self._direct_api("put", url=upload_url, data=data, headers={"Content-Length": clen, "Content-Range": cbrange}, timeout=7200)
                 data = file_like.read(self.upload_block_size)
                 cbfrom = cbto + 1
             return r
@@ -730,7 +730,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
     def download(self, oid, file_like):
         with self._api() as client:
             info = self._get_item(client, oid=oid)
-            r = self._direct_api("get", info.api_path + "/content", stream=True)
+            r = self._direct_api("get", info.api_path + "/content", stream=True, timeout=7200)
             for chunk in r.iter_content(chunk_size=4096):
                 file_like.write(chunk)
                 file_like.flush()

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -226,7 +226,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             return client.base_url.rstrip("/") + "/" + api_path
 
     # names of args are compat with requests module
-    def _direct_api(self, action, path=None, *, url=None, stream=None, data=None, headers=None, json=None, raw_response=False, timeout=600):  # pylint: disable=redefined-outer-name
+    def _direct_api(self, action, path=None, *, url=None, stream=None, data=None, headers=None, json=None, raw_response=False, timeout=240):  # pylint: disable=redefined-outer-name
         assert path or url
 
         if not url:


### PR DESCRIPTION
Default timeout set to 10 minutes. Timeout for upload/download set to 2 hours.