### PR TITLE
BI2-1300: Disconnect Error during large file upload

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -721,7 +721,10 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
             data = file_like.read(self.upload_block_size)
 
+            max_retries_per_block = 10
+
             cbfrom = 0
+            retries = 0  # per block
             while data:
                 clen = len(data)             # fragment content size
                 cbto = cbfrom + clen - 1     # inclusive content byte range
@@ -730,12 +733,16 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                     headers = {"Content-Length": clen, "Content-Range": cbrange}
                     r = self._direct_api("put", url=upload_url, data=data, headers=headers)
                 except (CloudDisconnectedError, CloudTemporaryError) as e:
-                    # Should we backoff here? Or have a max number of retries?
-                    log.exception("Exception during _upload_large, continuing, range=%s, exception: %s", cbrange, type(e))
-                    continue
+                    retries += 1
+                    log.exception("Exception during _upload_large, continuing, range=%s, exception%s: %s", cbrange, retries, type(e))
+                    if retries >= max_retries_per_block:
+                        raise e
+                    else:
+                        continue
 
                 data = file_like.read(self.upload_block_size)
                 cbfrom = cbto + 1
+                retries = 0
             return r
 
     def list_ns(self):

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -169,7 +169,9 @@ class OneDriveItem():
 class OneDriveProvider(Provider):         # pylint: disable=too-many-public-methods, too-many-instance-attributes
     case_sensitive = False
     default_sleep = 15
-    upload_block_size = 4 * 1024 * 1024
+    # Microsoft requests multiples of 320 KiB for upload_block_size
+    # https://docs.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0
+    upload_block_size = 10 * 320 * 1024
 
     name = 'onedrive'
     _base_url = 'https://graph.microsoft.com/v1.0/'

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -37,7 +37,7 @@ from cloudsync.registry import register_provider
 from cloudsync.utils import debug_sig, memoize
 
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 
 SOCK_TIMEOUT = 180
 

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -731,7 +731,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                     r = self._direct_api("put", url=upload_url, data=data, headers=headers)
                 except (CloudDisconnectedError, CloudTemporaryError) as e:
                     # Should we backoff here? Or have a max number of retries?
-                    log.exception("Exception during _upload_large, continuing, range=%s", cbrange)
+                    log.exception("Exception during _upload_large, continuing, range=%s, exception: %s", cbrange, type(e))
                     continue
 
                 data = file_like.read(self.upload_block_size)

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -824,13 +824,14 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
         pid = item["parentReference"].get("id")
         name = item["name"]
+        size = item["size"]
         mtime = item["lastModifiedDateTime"]
         shared = False
         if "createdBy" in item:
             shared = bool(item.get("remoteItem"))
 
         return OneDriveInfo(oid=iid, otype=otype, hash=ohash, path=path, pid=pid, name=name,
-                            mtime=mtime, shared=shared)
+                            size=size, mtime=mtime, shared=shared)
 
     def listdir(self, oid) -> Generator[OneDriveInfo, None, None]:
         with self._api() as client:

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -712,8 +712,8 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             with self._api() as client:
                 r = self._upload_large(self._get_item(client, path=path).api_path + ":", file_like, conflict="fail")
             return self._info_from_rest(r, root=self.dirname(path))
-
-    def _upload_large(self, drive_path, file_like, conflict):
+    
+    def _upload_large(self, drive_path, file_like, conflict):  # pylint: disable=too-many-locals
         with self._api():
             size = _get_size_and_seek0(file_like)
             r = self._direct_api("post", "%s/createUploadSession" % drive_path, json={"item": {"@microsoft.graph.conflictBehavior": conflict}})
@@ -724,7 +724,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             max_retries_per_block = 10
 
             cbfrom = 0
-            retries = 0  # per block
+            retries = 0
             while data:
                 clen = len(data)             # fragment content size
                 cbto = cbfrom + clen - 1     # inclusive content byte range
@@ -737,8 +737,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                     log.exception("Exception during _upload_large, continuing, range=%s, exception%s: %s", cbrange, retries, type(e))
                     if retries >= max_retries_per_block:
                         raise e
-                    else:
-                        continue
+                    continue
 
                 data = file_like.read(self.upload_block_size)
                 cbfrom = cbto + 1

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -36,7 +36,7 @@ from cloudsync.registry import register_provider
 from cloudsync.utils import debug_sig, memoize
 
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 
 
 class OneDriveFileDoneError(Exception):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,8 +1,9 @@
 """Imported test suite"""
 
 import io
+import requests
 from cloudsync.tests import *
-
+from unittest.mock import patch
 
 test_report_info = None
 
@@ -14,3 +15,65 @@ def test_report_info_od(provider):
     pinfo2 = provider.get_quota()
     assert pinfo2['used'] > 0
     assert pinfo2['limit'] > 0
+
+def test_interrupted_file_upload(provider):
+    # file_upload_size = 4 MiB, should take 12/4=3 API calls to upload file
+    file_size = 12 * 1024 * 1024
+    data = BytesIO(os.urandom(file_size))
+    dest = provider.temp_name("dest")
+
+    def hit_api(action, path=None, url=None, data=None, headers=None, json=None):
+        if not url:
+            url = provider._get_url(path)
+
+        with provider._api() as client:
+            if not url:
+                path = path.lstrip("/")
+                url = client.base_url + path
+            head = {
+                      'Authorization': 'bearer {access_token}'.format(access_token=client.auth_provider.access_token),
+                      'content-type': 'application/json'}
+            if headers:
+                head.update(headers)
+            for k in head:
+                head[k] = str(head[k])
+            log.debug("hit_api %s %s", action, url)
+            req = getattr(requests, action)(
+                url,
+                stream=None,
+                headers=head,
+                json=json,
+                data=data)
+
+        if req.status_code > 202:
+            raise Exception("Unknown error %s %s" % (req.status_code, req.json()))
+
+        res = req.json()
+        return res
+
+    # Every other attempt throws a DisconnectError
+    api_upload_calls = 0
+    def flaky_api(action, path=None, url=None, data=None, headers=None, json=None):
+        nonlocal api_upload_calls
+
+        # Temporary url is different every time, use Content-Range in header to identify upload call 
+        if headers and "Content-Range" in headers:
+            api_upload_calls += 1
+            if api_upload_calls % 2:
+                raise CloudDisconnectedError("Not connected")
+            else:
+                return hit_api(action, path, url, data, headers, json)
+
+        # Send all other api calls through to onedrive
+        else:
+            return hit_api(action, path, url, data, headers, json)
+
+    with patch.object(provider.prov, "_direct_api", side_effect=flaky_api):
+        provider.create(dest, data)
+
+    root_info = provider.info_path("/")
+    dir_list = list(provider.listdir(root_info.oid))
+    log.debug("dir_list=%s", dir_list)
+    assert len(dir_list) == 1
+    assert dir_list[0].size == file_size
+

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -49,5 +49,5 @@ def test_interrupted_file_upload(provider):
     provider.download(info.oid, new_fh)
     new_fh.seek(0, SEEK_END)
     new_len = new_fh.tell()
-    assert new_len == file_size
+    assert new_len == file_size #nosec
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -69,11 +69,11 @@ def test_interrupted_file_upload(provider):
             return hit_api(action, path, url, data, headers, json)
 
     with patch.object(provider.prov, "_direct_api", side_effect=flaky_api):
-        provider.create(dest, data)
+        info = provider.create(dest, data)
 
-    root_info = provider.info_path("/")
-    dir_list = list(provider.listdir(root_info.oid))
-    log.debug("dir_list=%s", dir_list)
-    assert len(dir_list) == 1
-    assert dir_list[0].size == file_size
+    new_fh = BytesIO()
+    provider.download(info.oid, new_fh)
+    new_fh.seek(0, SEEK_END)
+    new_len = new_fh.tell()
+    assert new_len == file_size
 


### PR DESCRIPTION
This change is the short fix proposed to solve the issues noticed in QA where disconnect errors during large file upload lead to many temporary files being created and the file failing to sync up after ~40 minutes. This fix includes catching the error and continuing the upload from the same spot in the file.

Notes:

1.  I'm wondering if it makes sense to implement any backoff or max retries when catching exceptions?
2. I added the size field to the OneDriveInfo. This should have been populated already, but additionally this made testing easier.