### PR TITLE
Fix post-rename path comparison

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -37,7 +37,7 @@ from cloudsync.registry import register_provider
 from cloudsync.utils import debug_sig, memoize
 
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 
 SOCK_TIMEOUT = 180
 

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -800,9 +800,9 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                 self.rename(oid, path)
 
         new_path = self._get_path(oid)
-        if new_path != path:
+        if not self.paths_match(path, new_path):
             log.error("path mismatch after rename -- wanted %s, got %s", path, new_path)
-            assert new_path == path  # must raise, cuz it's in the if block
+            raise CloudTemporaryError("path mismatch after rename")
 
         return oid
 


### PR DESCRIPTION
As discussed earlier today --
- return early if no rename changes deteceted (noop case)
- adjuste post-rename check: case-insensitive for dir, case-sensitive for filename: we expect at least one of these to have changed, if both match what we started with then raise a CloudTemporaryError