### PR TITLE
fetch sharepoint drives via sites API

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -23,7 +23,6 @@ import webbrowser
 from base64 import urlsafe_b64decode, b64encode
 import requests
 import arrow
-from urllib.parse import urlparse
 
 import onedrivesdk_fork as onedrivesdk
 from onedrivesdk_fork.error import OneDriveError, ErrorCode
@@ -31,7 +30,7 @@ from onedrivesdk_fork.http_response import HttpResponse
 
 from cloudsync import Provider, OInfo, DIRECTORY, FILE, NOTKNOWN, Event, DirInfo, OType
 from cloudsync.exceptions import CloudTokenError, CloudDisconnectedError, CloudFileNotFoundError, \
-    CloudFileExistsError, CloudCursorError, CloudTemporaryError, CloudException, CloudNamespaceError
+    CloudFileExistsError, CloudCursorError, CloudTemporaryError, CloudNamespaceError
 from cloudsync.oauth import OAuthConfig, OAuthProviderInfo
 from cloudsync.registry import register_provider
 from cloudsync.utils import debug_sig, memoize
@@ -345,7 +344,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
         for site in sites.get("value", []):
             try:
                 # TODO: use configurable regex for filtering?
-                url_path = urlparse(site["webUrl"]).path.lower()
+                url_path = urllib.parse.urlparse(site["webUrl"]).path.lower()
                 if url_path.startswith("/portals/"):
                     continue
 

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -39,6 +39,11 @@ class FakeGraphApi(FakeApi):
         self.called("quota", (ctx, req))
         return {'@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives/$entity', 'id': 'bdd46067213df13', 'driveType': 'personal', 'owner': {'user': {'displayName': 'Atakama --', 'id': 'bdd46067213df13'}}, 'quota': {'deleted': 15735784, 'remaining': 1104878763593, 'state': 'normal', 'total': 1104880336896, 'used': 1573303}}
 
+    @api_route("/me/drives")
+    def me_drives(self, ctx, req):
+        self.called("_set_drive_list", (ctx, req))
+        return {'@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives', 'value': [{'id': 'bdd46067213df13', 'name': 'personal'}]}
+
     @api_route("/drives/")
     def default(self, ctx, req):
         upload_url = self.uri("/upload")
@@ -138,7 +143,7 @@ def test_namespace_set_disconn():
 def test_namespace_set_other():
     _, odp = fake_odp()
 
-    def raise_error():
+    def raise_error(a, b):
         raise CloudTokenError("yo")
 
     with patch.object(odp, '_direct_api', side_effect=raise_error):

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -18,6 +18,8 @@ log = logging.getLogger(__name__)
 NEW_TOKEN = "weird-token-od"
 
 class FakeGraphApi(FakeApi):
+    multiple_personal_drives = False
+
     @api_route("/upload")
     def upload(self, ctx, req):
         self.called("upload", (ctx, req))
@@ -42,6 +44,8 @@ class FakeGraphApi(FakeApi):
     @api_route("/me/drives")
     def me_drives(self, ctx, req):
         self.called("_set_drive_list", (ctx, req))
+        if self.multiple_personal_drives:
+            return {'@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives', 'value': [{'id': 'bdd46067213df13', 'name': 'personal'}, {'id': '31fd31276064ddb', 'name': 'drive-2'}]}
         return {'@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives', 'value': [{'id': 'bdd46067213df13', 'name': 'personal'}]}
 
     @api_route("/drives/")
@@ -126,6 +130,13 @@ def test_namespace_get():
 def test_namespace_set():
     _, odp = fake_odp()
     odp.namespace = "personal"
+    nsid = odp.namespace_id
+    assert nsid
+
+def test_namespace_multiple_personal_drives():
+    srv, odp = fake_odp()
+    srv.multiple_personal_drives = True
+    odp.namespace = "personal/drive-2"
     nsid = odp.namespace_id
     assert nsid
 


### PR DESCRIPTION
added support for multiple drives within a site: https://vidaid.atlassian.net/browse/VFM-7335

as a bonus, now using sites API to fetch site list instead of groups API, which allows us to omit group read/write scope (permission) from our app -- group access requires admin approval.