### PR TITLE
VFM-7337: Url encode paths 

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -759,8 +759,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
     def _upload_large(self, drive_path, file_like, conflict):  # pylint: disable=too-many-locals
         with self._api():
             size = _get_size_and_seek0(file_like)
-            name = urllib.parse.quote(drive_path)
-            r = self._direct_api("post", "%s/createUploadSession" % name, json={"item": {"@microsoft.graph.conflictBehavior": conflict}})
+            r = self._direct_api("post", "%s/createUploadSession" % drive_path, json={"item": {"@microsoft.graph.conflictBehavior": conflict}})
             upload_url = r["uploadUrl"]
 
             data = file_like.read(self.upload_block_size)
@@ -820,10 +819,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             try:
                 updated = False
                 if info.name != base:
-                    need_temp = False
                     if info.name.lower() == base.lower():
-                        need_temp = True
-                    if need_temp:
                         new_info.name = base + os.urandom(8).hex()
                         item.update(new_info)
                     new_info.name = base

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -38,7 +38,7 @@ from cloudsync.utils import debug_sig, memoize
 import quickxorhash
 
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"
 
 SOCK_TIMEOUT = 180
 

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -378,7 +378,6 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             status = req.status_code
             try:
                 dat = req.json()
-                log.info(f"REED_DEBUG, json_response: {dat}")
                 msg = dat["error"]["message"]
                 code = dat["error"]["code"]
             except json.JSONDecodeError:

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -818,7 +818,8 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             try:
                 updated = False
                 if info.name != base:
-                    if info.name.lower() == base.lower():
+                    need_temp = info.name.lower() == base.lower()
+                    if need_temp:
                         new_info.name = base + os.urandom(8).hex()
                         item.update(new_info)
                     new_info.name = base

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -84,7 +84,7 @@ def test_url_encoding(provider):
     provider.listdir(sub_fold_info.oid)
 
     ents = list(provider.walk("/"))
-    assert len(ents) == len(expected_paths)
+    assert len(ents) == len(expected_paths) #nosec
     for ent in ents:
-        assert ent.path in expected_paths
+        assert ent.path in expected_paths #nosec
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,5 +1,5 @@
 """Imported test suite"""
-
+import urllib.parse
 import io
 import requests
 from cloudsync.tests import *
@@ -52,6 +52,14 @@ def test_interrupted_file_upload(provider):
     assert new_len == file_size #nosec
 
 def test_url_encoding(provider):
+    # Files with a pound causes OneDrive to throw an Error if not url encoded
     dest = provider.temp_name("dest ##.txt")
+    dest_empty = provider.temp_name("dest empty ##.txt")
     info = provider.create(dest, io.BytesIO(b"hello"))
-    log.info(f"REED_DEBUG, {info}")
+    provider.create(dest_empty, io.BytesIO())  #  Won't create session if file is empty
+    log.info(provider.info_path(dest))
+    log.info(provider.info_path(info.path))
+    log.info(provider.info_path(urllib.parse.quote(info.path)))
+    log.info(provider.info_oid(info.oid))
+    log.info(list(provider.listdir(root_info.oid)))
+    assert False

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -54,12 +54,16 @@ def test_interrupted_file_upload(provider):
 def test_url_encoding(provider):
     # Files with a pound causes OneDrive to throw an Error if not url encoded
     dest = provider.temp_name("dest ##.txt")
-    dest_empty = provider.temp_name("dest empty ##.txt")
+    fold = provider.temp_name("folder ##")
+    sub_fold = fold + "/sub folder ##"
+    dest_empty = fold + "/dest empty ##.txt"
+    log.info("Mkdir: %s" % provider.mkdir(fold))
+    provider.mkdir(sub_fold)
     info = provider.create(dest, io.BytesIO(b"hello"))
-    provider.create(dest_empty, io.BytesIO())  #  Won't create session if file is empty
-    log.info(provider.info_path(dest))
-    log.info(provider.info_path(info.path))
-    log.info(provider.info_path(urllib.parse.quote(info.path)))
-    log.info(provider.info_oid(info.oid))
-    log.info(list(provider.listdir(root_info.oid)))
+    empty_info = provider.create(dest_empty, io.BytesIO())  #  Won't create session if file is empty
+    provider.download(info.oid, io.BytesIO())
+    provider.delete(empty_info.oid)
+    fold_info = provider.info_path(fold)
+    log.info(list(provider.listdir(fold_info.oid)))
+    provider.rename(info.oid, provider.temp_name("another dest ##.txt"))
     assert False

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -51,3 +51,7 @@ def test_interrupted_file_upload(provider):
     new_len = new_fh.tell()
     assert new_len == file_size #nosec
 
+def test_url_encoding(provider):
+    dest = provider.temp_name("dest ##.txt")
+    info = provider.create(dest, io.BytesIO(b"hello"))
+    log.info(f"REED_DEBUG, {info}")


### PR DESCRIPTION
This was causing errors specifically around "#" being present in paths