### PR TITLE
Fix test_rename with [space]#

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -38,7 +38,7 @@ from cloudsync.utils import debug_sig, memoize
 import quickxorhash
 
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"
 
 SOCK_TIMEOUT = 180
 

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -809,7 +809,6 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
             old_parent_id = info.parent_reference.id
 
-            new_parent_item = self._get_item(client, path=parent)
             new_parent_info = self.info_path(parent)
             new_parent_id = new_parent_info.oid
 

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -810,8 +810,8 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             old_parent_id = info.parent_reference.id
 
             new_parent_item = self._get_item(client, path=parent)
-            new_parent_info = new_parent_item.get()
-            new_parent_id = new_parent_info.id
+            new_parent_info = self.info_path(parent)
+            new_parent_id = new_parent_info.oid
 
             new_info: onedrivesdk.Item = onedrivesdk.Item()
 
@@ -824,7 +824,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                         item.update(new_info)
                     new_info.name = base
                     updated = True
-                if old_parent_id != new_parent_info.id:
+                if old_parent_id != new_parent_info.oid:
                     new_info.parent_reference = onedrivesdk.ItemReference()
                     new_info.parent_reference.id = new_parent_id
                     updated = True
@@ -1009,8 +1009,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
     def exists_path(self, path) -> bool:
         try:
-            with self._api() as client:
-                return bool(self._get_item(client, path=path).get())
+            return bool(self.info_path(path))
         except CloudFileNotFoundError:
             return False
 

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -38,7 +38,7 @@ from cloudsync.utils import debug_sig, memoize
 import quickxorhash
 
 
-__version__ = "0.1.19"
+__version__ = "0.1.19" # pragma: no cover
 
 SOCK_TIMEOUT = 180
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -60,7 +60,8 @@ def test_url_encoding(provider):
     fold = provider.temp_name("fo'lder #'#")
     sub_fold = fold + "/sub f'o'lder ##"
     dest_empty = fold + "/dest empty '##'.txt"
-    sub_dest_empty = sub_fold + "/sub 'dest' empty ##.txt"
+    sub_dest = sub_fold + "/sub 'dest' empty ##.txt"
+    sub_dest_rename = sub_fold + "/sub rename 'dest' empty ##.txt"
 
     provider.mkdir(fold)
     expected_paths.append(fold)
@@ -70,13 +71,15 @@ def test_url_encoding(provider):
     info = provider.create(dest, io.BytesIO(b"hello"))
     provider.rename(info.oid, rename_dest)
     expected_paths.append(rename_dest)
+    #assert provider.exists_path(rename_dest)
     provider.download(info.oid, io.BytesIO())
 
     # Hits different endpoint if file is zero bytes
     empty_info = provider.create(dest_empty, io.BytesIO())
     provider.delete(empty_info.oid)
-    provider.create(sub_dest_empty, io.BytesIO(b"chow"))
-    expected_paths.append(sub_dest_empty)
+    sub_info = provider.create(sub_dest, io.BytesIO(b"chow"))
+    provider.rename(sub_info.oid, sub_dest_rename)
+    expected_paths.append(sub_dest_rename)
 
     fold_info = provider.info_path(fold)
     provider.listdir(fold_info.oid)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -71,7 +71,7 @@ def test_url_encoding(provider):
     info = provider.create(dest, io.BytesIO(b"hello"))
     provider.rename(info.oid, rename_dest)
     expected_paths.append(rename_dest)
-    #assert provider.exists_path(rename_dest)
+    assert provider.exists_path(rename_dest) #nosec
     provider.download(info.oid, io.BytesIO())
 
     # Hits different endpoint if file is zero bytes


### PR DESCRIPTION
It looks like the sdk doesn't play nice with the [space]# path scenario I've been working on. Specifically, the `get` method on OneDrive sdk items throws FileNotFoundErrors in this scenario. To fix the `provider.py::rename_test`, I moved away from the sdk for `exists_path` and `rename`. 

Tests were added to cover two scenarios originally overlooked:

1. calling `exists_path` with path containing [space]#
2. calling rename on a file with [space]# in the parent 

TODO: A more comprehensive overview of sdk use and path encoding