### PR TITLE
add exception handling to namespace_id setter

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -1144,7 +1144,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
     @namespace_id.setter
     def namespace_id(self, ns_id: str):
-        if self.__drive_to_name.get(ns_id, None):
+        if self.__drive_to_name.get(ns_id, None) or not self.connected:
             self._drive_id = ns_id
         else:
             raise CloudNamespaceError("Unknown namespace ID %s" % ns_id)

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -1144,7 +1144,10 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
     @namespace_id.setter
     def namespace_id(self, ns_id: str):
-        self._drive_id = ns_id
+        if self.__drive_to_name.get(ns_id, None):
+            self._drive_id = ns_id
+        else:
+            raise CloudNamespaceError("Unknown namespace ID %s" % ns_id)
 
     @classmethod
     def test_instance(cls):

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -1144,7 +1144,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
     @namespace_id.setter
     def namespace_id(self, ns_id: str):
-        if self.__drive_to_name.get(ns_id, None) or not self.connected:
+        if not self.connected or self.__drive_to_name.get(ns_id, None):
             self._drive_id = ns_id
         else:
             raise CloudNamespaceError("Unknown namespace ID %s" % ns_id)


### PR DESCRIPTION
This change will cause the provider.namespace_id setter to raise the CloudNamespaceError if the provided nsid is not valid when online, and allow the bad nsid when offline. The current behavior is to allow any nsid at any time, and raise CloudNamespaceError when performing a provider operation later. This change moves the CloudNamespaceError to the connect(). This means that, if you supply the nsid when offline, you don't need to catch CloudNamespaceError everywhere, depending on what the first operation will be after connecting that will raise this error, or put some expensive operation, like listdir, after connecting in order to provoke the error in a known location.