### PR TITLE
list_ns cleanup

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -340,6 +340,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                     drives.append(self._save_drive_info(f"personal/{drive['name']}", drive["id"]))
             else:
                 drives.append(self._save_drive_info("personal", me_drives[0]["id"]))
+            drives.sort(key=lambda d: d.name.lower())
             self._personal_drive = Site(name="personal", site_id="personal", drives=drives, cached=True)
             self.__cached_is_biz = me_drives[0]["driveType"] != 'personal'
         except CloudDisconnectedError:
@@ -366,12 +367,13 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
             except Exception as e:
                 log.warning("failed to get shared item info: %s", repr(e))
         if drives:
+            drives.sort(key=lambda d: d.name.lower())
             self._shared_with_me = Site(name="shared", site_id="shared", drives=drives, cached=True)
 
     def _fetch_sites(self):
         # sharepoint sites - a user can have access to multiple sites, with multiple drives in each
         sites = self._direct_api("get", "/sites?search=*").get("value", [])
-        sites.sort(key=lambda s: s["displayName"])
+        sites.sort(key=lambda s: s["displayName"].lower())
         for site in sites:
             try:
                 # TODO: use configurable regex for filtering?
@@ -386,7 +388,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
         if not site.cached:
             try:
                 site_drives = self._direct_api("get", f"/sites/{site.id}/drives").get("value", [])
-                site_drives.sort(key=lambda sd: sd["name"])
+                site_drives.sort(key=lambda sd: sd["name"].lower())
                 drives = []
                 for site_drive in site_drives:
                     drive = self._save_drive_info(f"{site.name}/{site_drive['name']}", site_drive["id"])

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -348,7 +348,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                     # ignore shared files
                     continue
                 drive_id = item["remoteItem"]["parentReference"]["driveId"]
-                path = urllib.parse.urlparse(item["webUrl"]).path.split('/')
+                path = urllib.parse.unquote_plus(urllib.parse.urlparse(item["webUrl"]).path).split('/')
                 if len(path) == 5:
                     # support only toplevel folders for now
                     all_drives[drive_id] = f"shared/{path[2]}/{path[3]}"
@@ -360,7 +360,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
         for site in sites.get("value", []):
             try:
                 # TODO: use configurable regex for filtering?
-                url_path = urllib.parse.urlparse(site["webUrl"]).path.lower()
+                url_path = urllib.parse.unquote_plus(urllib.parse.urlparse(site["webUrl"]).path).lower()
                 if url_path.startswith("/portals/"):
                     continue
 

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -340,7 +340,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                 for drive in drives:
                     self._save_drive_info(f"personal/{drive['name']}", drive["id"])
             else:
-                self._save_drive_info(f"personal", drives[0]["id"])
+                self._save_drive_info("personal", drives[0]["id"])
         except CloudDisconnectedError:
             raise
         except Exception as e:
@@ -417,7 +417,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
         #                     return drive.id
         # return id
 
-    def list_ns(self, recursive: bool = True, parent: Namespace = None):
+    def list_ns(self, recursive: bool = True, parent: Namespace = None) -> List[Namespace]:
         self._fetch_drive_list()
         if parent:
             site = self.__site_by_id.get(parent.id, None)

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -37,7 +37,7 @@ from cloudsync.utils import debug_sig, memoize
 
 import quickxorhash
 
-__version__ = "0.1.21" # pragma: no cover
+__version__ = "0.1.22" # pragma: no cover
 
 
 SOCK_TIMEOUT = 180

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -350,7 +350,8 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
                 drive_id = item["remoteItem"]["parentReference"]["driveId"]
                 path = urllib.parse.unquote_plus(urllib.parse.urlparse(item["webUrl"]).path).split('/')
                 if len(path) == 5:
-                    # support only toplevel folders for now
+                    # path looks something like "/sites/site-name/drive-name/path/to/folder" --
+                    # len=5 ensures we only consider toplevel folders (for now)
                     all_drives[drive_id] = f"shared/{path[2]}/{path[3]}"
             except Exception as e:
                 log.warning("failed to get shared item info: %s", repr(e))

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -415,7 +415,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
         self._fetch_drive_list()
         drive = self.__drive_by_id.get(drive_id, None)
         if not drive:
-            api_drive = self._direct_api("get", f"/drives/{drive_id}")
+            api_drive = self._direct_api("get", f"/drives/{drive_id}/")
             if api_drive:
                 drive = self._save_drive_info(api_drive["name"], drive_id)
         if not drive:

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -440,7 +440,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
         if parent:
             site = self.__site_by_id.get(parent.id, None)
             if not site:
-                log.error("Unknown parent namespace: %s / %s", parent.id, parent.name)
+                log.warning("Unknown parent namespace: %s / %s", parent.id, parent.name)
                 return []
             return self._fetch_drives_for_site(site)
         else:

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -37,7 +37,7 @@ from cloudsync.utils import debug_sig, memoize
 
 import quickxorhash
 
-__version__ = "1.0.0" # pragma: no cover
+__version__ = "1.0.1" # pragma: no cover
 
 
 SOCK_TIMEOUT = 180

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -37,7 +37,7 @@ from cloudsync.utils import debug_sig, memoize
 
 import quickxorhash
 
-__version__ = "0.1.22" # pragma: no cover
+__version__ = "1.0.0" # pragma: no cover
 
 
 SOCK_TIMEOUT = 180

--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -322,7 +322,7 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
         return res
 
-    def _set_drive_list(self):
+    def _set_drive_list(self):              # pylint: disable=too-many-branches
         all_drives: Dict[str, str] = {}
 
         # personal drive: "most users will only have a single drive resource" - Microsoft

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=["Intended Audience :: Developers",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires = ["cloudsync>=v1.4.15", "onedrivesdk_fork", "quickxorhash"]
+requires = ["cloudsync>=v1.5.0", "onedrivesdk_fork", "quickxorhash"]
 requires-python = ">=3.6"
 
 [tool.flit.entrypoints.cloudsync.providers]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=["Intended Audience :: Developers",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires = ["cloudsync>=v1.5.0", "onedrivesdk_fork", "quickxorhash"]
+requires = ["cloudsync>=v1.5.1", "onedrivesdk_fork", "quickxorhash"]
 requires-python = ">=3.6"
 
 [tool.flit.entrypoints.cloudsync.providers]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=["Intended Audience :: Developers",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires = ["cloudsync>=v1.4.14", "onedrivesdk_fork", "quickxorhash"]
+requires = ["cloudsync>=v1.4.15", "onedrivesdk_fork", "quickxorhash"]
 requires-python = ">=3.6"
 
 [tool.flit.entrypoints.cloudsync.providers]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=["Intended Audience :: Developers",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires = ["cloudsync>=v1.4.8", "onedrivesdk_fork", "quickxorhash"]
+requires = ["cloudsync>=v1.4.14", "onedrivesdk_fork", "quickxorhash"]
 requires-python = ">=3.6"
 
 [tool.flit.entrypoints.cloudsync.providers]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest-coverage
 pytest-timeout
 pytest-xdist
 # from pyproject.toml
-cloudsync>=v1.4.8
+cloudsync>=v1.4.14
 onedrivesdk_fork
 quickxorhash
 codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest-coverage
 pytest-timeout
 pytest-xdist
 # from pyproject.toml
-cloudsync>=v1.4.14
+cloudsync>=v1.4.15
 onedrivesdk_fork
 quickxorhash
 codecov

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from onedrivesdk_fork.error import ErrorCode
-from cloudsync.exceptions import CloudNamespaceError, CloudDisconnectedError, CloudTokenError
+from cloudsync.exceptions import CloudNamespaceError, CloudDisconnectedError, CloudTokenError, CloudFileNotFoundError
 from cloudsync.tests.fixtures import FakeApi, fake_oauth_provider
 from cloudsync.oauth.apiserver import ApiError, api_route
 from cloudsync_onedrive import OneDriveProvider
@@ -316,3 +316,10 @@ def test_list_namespaces():
     namespaces = [ns.name for ns in odp2.list_ns(recursive=True)]
     # fetch additional info for 2 sites
     assert len(api2.calls["_fetch_sites"]) == 3
+
+def test_drive_id_name_translation():
+    _, odp = fake_odp()
+    with pytest.raises(CloudFileNotFoundError):
+        _ = odp._drive_id_to_name("not-an-id")
+    with pytest.raises(CloudNamespaceError):
+        _ = odp._drive_name_to_id("cloudsync-test-1/Documents")

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -46,8 +46,8 @@ class FakeGraphApi(FakeApi):
     def me_drives(self, ctx, req):
         self.called("_fetch_personal_drives", (ctx, req))
         if self.multiple_personal_drives:
-            return {'@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives', 'value': [{'id': 'bdd46067213df13', 'name': 'personal'}, {'id': '31fd31276064ddb', 'name': 'drive-2'}]}
-        return {'@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives', 'value': [{'id': 'bdd46067213df13', 'name': 'personal'}]}
+            return {'@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives', 'value': [{'id': 'bdd46067213df13', 'driveType': 'business', 'name': 'personal'}, {'id': '31fd31276064ddb', 'driveType': 'business', 'name': 'drive-2'}]}
+        return {'@odata.context': 'https://graph.microsoft.com/v1.0/$metadata#drives', 'value': [{'id': 'bdd46067213df13', 'driveType': 'business', 'name': 'personal'}]}
 
     @api_route("/me/drive/sharedWithMe")
     def me_drive_shared_with_me(self, ctx, req):
@@ -220,7 +220,7 @@ def fake_odp():
     with patch.object(OneDriveProvider, "_base_url", base_url):
         prov = fake_oauth_provider(srv, OneDriveProvider)
         assert srv.calls["token"]
-        assert srv.calls["quota"]
+        assert srv.calls["_fetch_personal_drives"]
         # onedrive saves refresh token if creds change
         assert prov._creds["refresh_token"] == NEW_TOKEN
         return srv, prov

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -294,7 +294,8 @@ def test_namespace_set_other():
 
 def test_list_namespaces():
     api, odp = fake_odp()
-    namespaces = [ns.name for ns in odp.list_ns(recursive=False)]
+    namespace_objs = odp.list_ns(recursive=False)
+    namespaces = [ns.name for ns in namespace_objs]
     # personal is always there
     assert "personal" in namespaces
     # shared folders - fake namespace
@@ -308,12 +309,22 @@ def test_list_namespaces():
     assert "cloudsync-sub-site-1" in namespaces
     # protals are ignored
     assert "Community" not in namespaces
+    # site fetch done only once
     assert len(api.calls["_fetch_sites"]) == 1
+    # personal has no children
+    child_namespaces = odp.list_ns(parent=namespace_objs[0])
+    assert len(child_namespaces) == 0
+    # shared has 2 children
+    child_namespaces = odp.list_ns(parent=namespace_objs[1])
+    assert len(child_namespaces) == 2
 
+    # recursive
     api2, odp2 = fake_odp()
-    namespaces = [ns.name for ns in odp2.list_ns(recursive=True)]
+    namespaces = odp2.list_ns(recursive=True)
     # fetch additional info for 2 sites
     assert len(api2.calls["_fetch_sites"]) == 3
+
+
 
 def test_drive_id_name_translation():
     _, odp = fake_odp()

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -250,7 +250,7 @@ def test_namespace_set_other():
 
 def test_list_namespaces():
     _, odp = fake_odp()
-    namespaces = odp.list_ns()
+    namespaces = [ns.name for ns in odp.list_ns()]
     # personal is always there
     assert "personal" in namespaces
     # shared folder from a sharepoint site

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -297,10 +297,8 @@ def test_list_namespaces():
     namespaces = [ns.name for ns in odp.list_ns(recursive=False)]
     # personal is always there
     assert "personal" in namespaces
-    # shared folder from a sharepoint site
-    assert "shared/site-1/documents" in namespaces
-    # shared folder from a personal drive (private sharepoint site)
-    assert "shared/user_co_onmicrosoft_com/Documents" in namespaces
+    # shared folders - fake namespace
+    assert "shared" in namespaces
     # shared inner folder (parent is not root) is ignored
     assert "shared/user2_co_onmicrosoft_com/Documents" not in namespaces
     # shared file is ignored


### PR DESCRIPTION
- sort namespace list: personal > shared > sites listed individually (alphabetical, case insensitive)
- sort drives (alphabetical, case insensitive)
- grouped all shared folders under a "shared" node in the namespace tree
- fixed drive-by-id lookup
- improved test coverage