### PR TITLE
fix reauth flow

### DIFF
--- a/cloudsync_onedrive.py
+++ b/cloudsync_onedrive.py
@@ -700,11 +700,15 @@ class OneDriveProvider(Provider):         # pylint: disable=too-many-public-meth
 
                 self._fetch_drive_list(clear_cache=True)
                 if self.connection_id and self.connection_id != self._personal_drive.drives[0].drive_id:
-                    self.__client = None
+                    self.disconnect()
                     raise CloudTokenError("Cannot connect with mismatched credentials")
 
                 # validate namespace if specified, default to personal drive if not
-                self.namespace_id = self.namespace_id or self._personal_drive.drives[0].id
+                try:
+                    self.namespace_id = self.namespace_id or self._personal_drive.drives[0].id
+                except:
+                    self.disconnect()
+                    raise
 
         return self._personal_drive.drives[0].drive_id
 

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -516,9 +516,9 @@ def test_namespace_set_other():
         raise CloudTokenError("yo")
 
     with patch.object(odp, '_direct_api', side_effect=raise_error):
-        with pytest.raises(CloudTokenError):
+        with pytest.raises(CloudNamespaceError):
             odp.namespace = Namespace(name="whatever", id="item-not-found")
-        with pytest.raises(CloudTokenError):
+        with pytest.raises(CloudNamespaceError):
             odp.namespace_id = "item-not-found"
 
 

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -649,9 +649,15 @@ def test_connect_raises_token_errors():
     # ensure connectivity errors bubble up
     with patch.object(OneDriveProvider, "_base_url", api.uri()):
         with patch.object(odp, '_direct_api', side_effect=direct_api_raises_errors):
-            odp.reconnect()
             with pytest.raises(CloudTokenError):
-                odp.list_ns()
+                odp.reconnect()
+
+    # creds mismatch = CloudTokenError
+    odp.disconnect()
+    odp.connection_id = "creds-mismatch"
+    with patch.object(odp, "_fetch_drive_list"):
+        with pytest.raises(CloudTokenError):
+            odp.reconnect()
 
 
 def test_connect_exception_handling():

--- a/tests/test_onedrive.py
+++ b/tests/test_onedrive.py
@@ -506,6 +506,7 @@ def test_namespace_set_disconn():
     with patch.object(OneDriveProvider, "_base_url", srv.uri()):
         with pytest.raises(CloudNamespaceError):
             odp.reconnect()
+        assert not odp.connected
 
 
 def test_namespace_set_other():


### PR DESCRIPTION
- disconnect on creds mismatch and namespace set failure
- perform namespace set inside _api context (with mutex lock)